### PR TITLE
Update logo SVG

### DIFF
--- a/tokens/novusphereio/ATMOS.json
+++ b/tokens/novusphereio/ATMOS.json
@@ -4,7 +4,7 @@
   "account": "novusphereio",
   "precision": 3,
   "issuer": "novusphereio",
-  "logo": "https://raw.githubusercontent.com/BlockABC/eos-tokens/master/tokens/novusphereio/ATMOS.svg",
+  "logo": "https://novusphere.io/static/img/logo.svg",
   "desc": "",
   "website": "",
   "whitepaper": "",


### PR DESCRIPTION
GitHub does not serve SVG mime type correctly and it cannot be used via GitHub CDN